### PR TITLE
BraGoTransferイベント発火したら自動で画面を更新させる

### DIFF
--- a/src/app/app/hooks/useBalance.tsx
+++ b/src/app/app/hooks/useBalance.tsx
@@ -46,9 +46,7 @@ export const TokenBalance = (): TokenProps => {
         setSent(sendTokenCount);
         setReceived(recvTokenCount);
 
-
-
-    }, [isContractLoading, logLoading])
+    }, [isContractLoading, logLoading, transferLogs])
 
     // useEffect(() => {
     // // sent が更新された後に localStorage に保存します


### PR DESCRIPTION
BraGoTransferイベントが発火したら再度ログを集めに行く実装を加えました。
→この作りのため、トークン送信（受信）後、数秒のラグがあってから画面が更新されます。

この実装だとログが増えていくとオーバーヘッドが大きくなってしまうのであまり良い実装とは正直言えないのですが、
今回のハッカソン向けであれば十分だと思っています。
問題なければマージお願いします。